### PR TITLE
fix: Update operations.js

### DIFF
--- a/lib/operations.js
+++ b/lib/operations.js
@@ -6,7 +6,7 @@ const log_config = require('./logConfig');
 const {Signale} = require('signale');
 const log = new Signale(log_config.options);
 
-const allowed_operations = ['ADD', 'SEARCH', 'DELETE', 'UPDATE'];
+const allowed_operations = ['ADD', 'SEARCH', 'REMOVE', 'UPDATE'];
 
 function add(server, verbose) {
   if (!utils.updateServer(server, verbose)) {


### PR DESCRIPTION
Though the warning states:
[custom] › ⚠  warning       Invalid operations. One of ADD,SEARCH,DELETE,UPDATE is required

There's no DELETE function/operation.

The error/warning message should say REMOVE instead.